### PR TITLE
Task/DES-2336:  load most recent map project fix

### DIFF
--- a/src/app/components/control-bar/control-bar.component.html
+++ b/src/app/components/control-bar/control-bar.component.html
@@ -85,7 +85,7 @@
     <a
       class="button-spacing"
       mat-raised-button
-      href="{{ hazMapperLink }}"
+      href="{{ hazmapperLink }}"
       title="Open your gallery in HazMapper"
       target="_blank"
     >

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -180,8 +180,6 @@ export class ControlBarComponent implements OnInit {
           // default to the first project in the list
           this.projectsService.setActiveProject(this.projects[0]);
         }
-      } else {
-        this.projectsService.setActiveProject(null);
       }
 
       this.groupsService.selectedImages.subscribe((next) => {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -172,7 +172,6 @@ export class ControlBarComponent implements OnInit {
       } catch (error) {
         // possible that lastProj item is null and not json
         lastProject = null;
-        console.log(window.localStorage.getItem('lastProj'));
       }
 
       if (projects.length) {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -165,24 +165,24 @@ export class ControlBarComponent implements OnInit {
     this.projectsService.projects.subscribe((projects) => {
       this.projects = projects;
 
-      if (this.projects.length) {
-        let lastProj;
-        // try {
-        //   //restores view to the last visited project from local storage
-        //   lastProj = JSON.parse(window.localStorage.getItem('lastProj'));
-        //   // console.log(lastProj);
-        // } catch (error) {
-        //   lastProj = this.projectsService.setActiveProject(this.projects[0]);
-        // }
+      // restores view to the last visited project from local storage
+      let lastProject = null;
+      try {
+        lastProject = JSON.parse(window.localStorage.getItem('lastProj'));
+      } catch (error) {
+        // possible that lastProj item is null and not json
+        lastProject = null;
+        console.log(window.localStorage.getItem('lastProj'));
+      }
 
-        lastProj = this.projectsService.setActiveProject(this.projects[0]);
-
-        // If lastProj is null, then there is no project saved, or can be found, default to the first project in the list
-        if (lastProj == 'none' || lastProj == null) {
-          lastProj = this.projects[0];
+      if (projects.length) {
+        const selectedLastProject = lastProject ? this.projects.find((prj) => prj.id === lastProject.id) : null;
+        if (selectedLastProject) {
+          this.projectsService.setActiveProject(selectedLastProject);
+        } else {
+          // default to the first project in the list
+          this.projectsService.setActiveProject(this.projects[0]);
         }
-
-        this.projectsService.setActiveProject(lastProj);
       }
 
       this.groupsService.selectedImages.subscribe((next) => {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -214,7 +214,6 @@ export class ControlBarComponent implements OnInit {
 
   selectProject(p: Project): void {
     this.projectsService.setActiveProject(p);
-    this.getDataForProject(p);
   }
 
   getDataForProject(p: Project): void {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -10,7 +10,7 @@ import { Feature, Project, TagGroup } from '../../models/models';
 import { FeatureCollection } from 'geojson';
 import { GeoDataService } from '../../services/geo-data.service';
 import { LatLng } from 'leaflet';
-import { skip, startWith } from 'rxjs/operators';
+import { skip } from 'rxjs/operators';
 import { BsModalRef, BsModalService } from 'ngx-foundation';
 import { ModalFileBrowserComponent } from '../modal-file-browser/modal-file-browser.component';
 import { ModalDownloadSelectorComponent } from '../modal-download-selector/modal-download-selector.component';

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -180,6 +180,8 @@ export class ControlBarComponent implements OnInit {
           // default to the first project in the list
           this.projectsService.setActiveProject(this.projects[0]);
         }
+      } else {
+        this.projectsService.setActiveProject(null);
       }
 
       this.groupsService.selectedImages.subscribe((next) => {
@@ -193,10 +195,12 @@ export class ControlBarComponent implements OnInit {
 
     this.projectsService.activeProject.subscribe((next) => {
       this.selectedProject = next;
-      this.getDataForProject(this.selectedProject);
-      // retrieves uuid for project, formats result into a link to that Hazmapper map
-      this.hazmapperLink =
-        'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + next.uuid;
+      if (this.selectedProject) {
+        this.getDataForProject(this.selectedProject);
+        // retrieves uuid for project, formats result into a link to that Hazmapper map
+        this.hazmapperLink =
+          'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + next.uuid;
+      }
     });
 
     this.geoDataService.mapMouseLocation.pipe(skip(1)).subscribe((next) => {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -281,10 +281,6 @@ export class ControlBarComponent implements OnInit {
         uuid: project.uuid,
       },
     });
-
-    modal.afterClosed().subscribe((passbackData: Array<string>) => {
-      this.projectsService.setActiveProject(this.projects[0]);
-    });
   }
 
   addGroup(name: string) {

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -16,7 +16,7 @@ import { ModalFileBrowserComponent } from '../modal-file-browser/modal-file-brow
 import { ModalDownloadSelectorComponent } from '../modal-download-selector/modal-download-selector.component';
 import { ModalCreateProjectComponent } from '../modal-create-project/modal-create-project.component';
 import { ModalShareProjectComponent } from '../modal-share-project/modal-share-project.component';
-import { interval, Observable, Subscription, combineLatest } from 'rxjs';
+import { combineLatest } from 'rxjs';
 import { RemoteFile } from 'ng-tapis';
 import { GroupsService } from '../../services/groups.service';
 import { FormsService } from '../../services/forms.service';
@@ -27,11 +27,9 @@ import {
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { ModalCurrentProjectComponent } from '../modal-current-project/modal-current-project.component';
-import { AppEnvironment, environment } from '../../../environments/environment';
-import { feature } from '@turf/helpers';
+import { environment } from '../../../environments/environment';
 import { TapisFilesService } from '../../services/tapis-files.service';
-import { element } from 'protractor';
-import { consoleTestResultHandler } from 'tslint/lib/test';
+
 import { ScrollService } from 'src/app/services/scroll.service';
 import { NotificationsService } from 'src/app/services/notifications.service';
 import { FeatureService } from 'src/app/services/feature.service';

--- a/src/app/components/modal-current-project/modal-current-project.component.html
+++ b/src/app/components/modal-current-project/modal-current-project.component.html
@@ -1,7 +1,6 @@
 <h4>Current Gallery</h4>
 <form
   [formGroup]="projCreateForm"
-  (ngSubmit)="update()"
   id="current-project-form"
 >
   <mat-form-field>
@@ -45,6 +44,7 @@
       color="primary"
       class="button small align-right"
       type="submit"
+      (click)="update()"
       [disabled]="!projCreateForm.valid"
     >
       Update

--- a/src/app/components/modal-current-project/modal-current-project.component.ts
+++ b/src/app/components/modal-current-project/modal-current-project.component.ts
@@ -52,24 +52,6 @@ export class ModalCurrentProjectComponent implements OnInit {
   }
 
   update() {
-    // The project is being properly assembled, but the problem is that the returned project isn't updating.
-    // Do I need more data in my projects?
-    /*
-      export interface Project {
-      description: string;
-      id?: number;
-      name: string;
-      ds_id?: string;
-      title?: string;
-      uuid?: string;
-      public?: boolean;
-      system_file?: string;
-      system_id?: string;
-      system_path?: string;
-      deleting?: boolean;
-      deletingFailed?: boolean;
-    }
-     */
     const p = new Project();
     const projRqst = new ProjectRequest();
 

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -5,7 +5,6 @@ import { tap } from 'rxjs/operators';
 import { Project, IProjectUser, ProjectRequest } from '../models/models';
 import { environment } from '../../environments/environment';
 import { AuthService } from './authentication.service';
-import { validateBBox } from '@turf/helpers';
 import { NotificationsService } from './notifications.service';
 
 @Injectable({

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -66,20 +66,16 @@ export class ProjectsService {
     );
   }
 
-  create(data: ProjectRequest): Observable<Project> {
-    const prom = this.http.post<Project>(
+  create(data: ProjectRequest) {
+    this.http.post<Project>(
       environment.apiUrl + `/projects/`,
       data
-    );
-    prom.subscribe((proj) => {
+    ).subscribe((proj) => {
+      // bug in geoapi where deletable is not returned in response so assuming its deletable
+      proj = {...proj, deletable: true};
+      this.setActiveProject(proj);
       this._projects.next([...this._projects.value, proj]);
-
-      // Awkward as hell, but this ensures we actually transition to the newly created project
-      // Without this, the screen flickers briefly to the new project, but ends up stuck on the old project
-      this.setActiveProject(proj);
-      this.setActiveProject(proj);
     });
-    return prom;
   }
 
   setActiveProject(proj: Project): void {

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -71,7 +71,7 @@ export class ProjectsService {
       environment.apiUrl + `/projects/`,
       data
     ).subscribe((proj) => {
-      // bug in geoapi where deletable is not returned in response so assuming its deletable
+      // Adding deletable attribute as missing from response https://jira.tacc.utexas.edu/browse/DES-2381
       proj = {...proj, deletable: true};
       this.setActiveProject(proj);
       this._projects.next([...this._projects.value, proj]);

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -97,6 +97,7 @@ export class ProjectsService {
       .put<Project>(environment.apiUrl + `/projects/${data.project.id}/`, data)
       .subscribe((resp) => {
         this._activeProject.next(resp);
+        this.getProjects();
       });
   }
 

--- a/src/app/services/projects.service.ts
+++ b/src/app/services/projects.service.ts
@@ -55,12 +55,12 @@ export class ProjectsService {
   // Queries database for all user projects.
   getProjects(): void {
     this.http.get<Project[]>(environment.apiUrl + `/projects/`).subscribe(
-      (resp) => {
-        this.updateProjectsList(resp);
+      (projects) => {
+        this._projects.next(projects);
       },
       (error) => {
         this.notificationsService.showErrorToast(
-          'Error importing files Design Safe, GeoAPI might be down'
+          'Error getting projects DesignSafe or GeoAPI might be down'
         );
       }
     );


### PR DESCRIPTION
## Overview: ##

This PR:
* loads the most recent map (if it exists)
* if the user updates name of project then that is automatically shown in project list
* provides work-around from geoapi bug and assume that newly created projects are deletable
* fix for hazmapper link

## Related Jira tickets: ##

* [DES-2336](https://jira.tacc.utexas.edu/browse/DES-2336)


## Testing Steps: ##

Hazmapper link
1.  check hazmapper link

update of project name
1. update project name
2. ensure project name is updated in list

created projects are deletable
1. create project
2. see if project is delectable (without refresh)

Map loading
1. ensure most recent map is reloaded
2. ensure it handles if most recent map was deleted that another map is picked
3. ensure it handles the scenario that all maps were deleted (use local geoapi server for this)

## NOTES ##


Todo:
- [x] handle the deletion of last project; and when no existing projects.  there is an error there.
- [x] create Jira issue for the geoapi bug related to creation response and missing `deletable` attribute (https://jira.tacc.utexas.edu/browse/DES-2381)