### PR TITLE
Fix and add styles back in taggit.

### DIFF
--- a/src/app/components/control-bar/control-bar.component.html
+++ b/src/app/components/control-bar/control-bar.component.html
@@ -85,7 +85,7 @@
     <a
       class="button-spacing"
       mat-raised-button
-      href="{{ hazMapperLink }}"
+      href="{{ hazmapperLink }}"
       title="Open your gallery in HazMapper"
       target="_blank"
     >

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -198,6 +198,7 @@ export class ControlBarComponent implements OnInit {
       this.selectedProject = next;
       this.getDataForProject(this.selectedProject);
       // retrieves uuid for project, formats result into a link to that Hazmapper map
+      console.log(next.uuid);
       this.hazmapperLink =
         'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + next.uuid;
     });

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -198,7 +198,6 @@ export class ControlBarComponent implements OnInit {
       this.selectedProject = next;
       this.getDataForProject(this.selectedProject);
       // retrieves uuid for project, formats result into a link to that Hazmapper map
-      console.log(next.uuid);
       this.hazmapperLink =
         'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + next.uuid;
     });

--- a/src/app/components/side-bar/tag-images/form-generator/form-fields/form-color/form-color.component.ts
+++ b/src/app/components/side-bar/tag-images/form-generator/form-fields/form-color/form-color.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 import { FormsService } from 'src/app/services/forms.service';
 import { Feature, Project, GroupForm, TagGroup } from 'src/app/models/models';
 import { GeoDataService } from 'src/app/services/geo-data.service';
+import { ProjectsService } from 'src/app/services/projects.service';
 
 @Component({
   selector: 'app-form-color',
@@ -18,11 +19,15 @@ export class FormColorComponent implements OnInit {
   @Input() label: String;
 
   public chosenTag: string;
+  public activeProject: Project;
+  public activeGroup: TagGroup;
+  public activeGroupFeature: Feature;
   public chosenColor = '#ffffff';
   value: any = {};
 
   constructor(
     private formsService: FormsService,
+    private projectsService: ProjectsService,
     private geoDataService: GeoDataService
   ) {}
 
@@ -32,18 +37,28 @@ export class FormColorComponent implements OnInit {
       this.chosenTag = this.value.label;
       this.formValue.emit({ id: this.form.id, value: this.value });
     });
+
+    this.projectsService.activeProject.subscribe((next) => {
+      this.activeProject = next;
+    });
+
+    this.geoDataService.activeGroup.subscribe((next: TagGroup) => {
+      this.activeGroup = next;
+    });
+
+    this.geoDataService.activeGroupFeature.subscribe((next) => {
+      this.activeGroupFeature = next;
+    });
   }
 
   updateCheckedTag() {
     this.value = this.form.options.find((opt) => opt.label === this.chosenTag);
-    // TODO: Move this to somewhere else?
-    // Objective is to save both tag and color
-    // this.formsService.saveStyles(
-    //   this.activeProject.id,
-    //   this.value.color,
-    //   this.activeGroup,
-    //   this.activeGroupFeature
-    // );
+    this.formsService.saveStyles(
+      this.activeProject.id,
+      [this.activeGroupFeature],
+      this.activeGroup,
+      this.value.color
+    );
     this.formValue.emit({ id: this.form.id, value: this.value });
   }
 }

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -174,9 +174,13 @@ export class FeatureAsset implements IFeatureAsset {
   }
 }
 
-interface FeatureStyles {
-  [key: string]: string | number;
+export interface FeatureStyles {
+  // [key: string]?: string | number;
+  faIcon?: string;
+  color?: string;
 }
+
+export class FeatureStyles implements FeatureStyles {}
 
 export interface Overlay {
   id: number;

--- a/src/app/services/forms.service.ts
+++ b/src/app/services/forms.service.ts
@@ -90,19 +90,22 @@ export class FormsService {
   // This method accesses group services to retrive the current group's icon as well
   saveStyles(
     projectId: number,
-    selectedColor: string,
+    featureList: Feature[],
     group: TagGroup,
-    feature: Feature
+    color?: string,
+    icon?: string
   ) {
-    group.color = this.checkDefault(selectedColor, feature);
-
     const style = {
-      faIcon: group.icon,
-      color: group.color,
+      color: color ? color : '#00C8FF',
+      faIcon: icon ? icon : group.icon,
     };
 
-    this.geoDataService.updateGroupFeatures(projectId, [feature], group);
-    this.geoDataService.updateFeatureStyle(projectId, feature.id, style);
+    this.geoDataService.updateGroupFeatures(
+      projectId,
+      featureList,
+      group,
+      style
+    );
   }
 
   updateTagValue(


### PR DESCRIPTION
Testing Steps:
1. Add Create a group
2. Ensure the group's styles (color, icon) are set correctly (in hazmapper)
3. Try adding a color tag and ensure it works (in hazmapper)
4. Try changing the icon in the group select view.
5. Ensure that that displays properly (in hazmapper)

Concerns:
1. Features in overlapping groups are mutable to group modification events.
Added in the feature for now but unsure how we would go further

2. I think the QGIS conventions recognize `feature.style` instead of our convention `feature.properties.style`. This might break compatibility of our geojson with external apps.