### PR TITLE
Task/wg 80 fix link to hazmapper

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ## Related Jira tickets: ##
 
-* [DES-9999](https://jira.tacc.utexas.edu/browse/DES-9999)
+* [WG-999](https://jira.tacc.utexas.edu/browse/WG-999)
 
 ## Summary of Changes: ##
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,16 @@
-# Single Page App Demo
+# Taggit
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.3.3.
+[Taggit](https://www.designsafe-ci.org/ds-use-case/haan/usecase/) allows users to browse images files on DesignSafe and tag them for 
+later use in analysis or mapping applications. It also easily connects to [HazMapper](https://github.com/TACC-Cloud/hazmapper) to map image locations. 
 
-## Development server
+## Development setup
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Use node v14.x, run:
 
-## Code scaffolding
+```
+npm install
+npm run start.
+```
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+Then, navigate to `http://localhost:4200/`.
 
-## Build
-
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
-
-## Running unit tests
-
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -218,7 +218,7 @@ export class ControlBarComponent implements OnInit {
         this.getDataForProject(this.selectedProject);
         // retrieves uuid for project, formats result into a link to that Hazmapper map
         this.hazmapperLink =
-          'https://hazmapper.tacc.utexas.edu/hazmapper/project/' + next.uuid;
+          this.envService.hazmapperUrl + '/project/' + next.uuid;
       }
     });
 


### PR DESCRIPTION
## Overview: ##

This PR fixes **the link to the related Hazmapper map** by but also updates README/pr-template.

## Related Jira tickets: ##

* [WG-80](https://jira.tacc.utexas.edu/browse/DES-80)

## Testing Steps: ##
1. update `src/environments/environment.ts` to use staging (i.e. `backend: EnvironmentType.Staging`)
2. Ensure that the link to the hazmapper map brings you to an existing map on staging.