### PR TITLE
task/WG-140: add app information to request for analytics-related logging

### DIFF
--- a/src/app/app.interceptors.ts
+++ b/src/app/app.interceptors.ts
@@ -68,31 +68,60 @@ export class TokenInterceptor implements HttpInterceptor {
       });
     }
 
-    // for guest users, add a custom header with a unique id
-    if (!this.authSvc.isLoggedIn()) {
-      // Get (or create of needed) the guestUserID in local storage
-      let guestUuid = localStorage.getItem('guestUuid');
-
-      if (!guestUuid) {
-        guestUuid = uuidv4();
-        localStorage.setItem('guestUuid', guestUuid);
-      }
-      request = request.clone({
-        setHeaders: {
-          'X-Guest-UUID': guestUuid,
-        },
-      });
-    }
-
-    if(request.url.indexOf(this.envService.apiUrl) > -1) {
+    if (request.url.indexOf(this.envService.apiUrl) > -1) {
       // Add information about what app is making the request
-      request = request.clone({
+
+      // Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
+      // and using additional query params
+      let analytics_params = {};
+
+      /*request = request.clone({
         setHeaders: {
-          'X-Geoapi-Application': 'taggit',
+          'X-Geoapi-Application': 'hazmapper',
         },
-      });
+      });*/
+
+      analytics_params = { ...analytics_params, application: 'hazmapper' };
+
+      // for guest users, add a unique id
+      if (!this.authSvc.isLoggedIn()) {
+        // Get (or create of needed) the guestUserID in local storage
+        let guestUuid = localStorage.getItem('guestUuid');
+
+        if (!guestUuid) {
+          guestUuid = uuidv4();
+          localStorage.setItem('guestUuid', guestUuid);
+        }
+        /*Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
+        request = request.clone({
+          setHeaders: {
+            'X-Guest-UUID': guestUuid,
+          },
+        });
+        */
+        analytics_params = { ...analytics_params, guest_uuid: guestUuid };
+      }
+      /* Send analytics-related params to projects endpoint only (until we use headers
+        again in https://tacc-main.atlassian.net/browse/WG-192) */
+      if (this.isProjectFeaturesRequest(request)) {
+        // Clone the request and add query parameters
+        request = request.clone({
+          setParams: { ...request.params, ...analytics_params },
+        });
+      }
     }
 
     return next.handle(request);
+  }
+
+  /**
+   * Determines whether a given HTTP request targets the features endpoint of a project or public project.
+   *
+   * This endpoint is being logged with extra information for analytics purposes.
+   */
+  private isProjectFeaturesRequest(request: HttpRequest<any>): boolean {
+    // Regular expression to match /projects/{projectId}/features or /public-projects/{projectId}/features
+    const urlPattern = /\/(projects|public-projects)\/\d+\/features\/?(?:\?.*)?/;
+    return request.method === 'GET' && urlPattern.test(request.url);
   }
 }

--- a/src/app/app.interceptors.ts
+++ b/src/app/app.interceptors.ts
@@ -84,6 +84,15 @@ export class TokenInterceptor implements HttpInterceptor {
       });
     }
 
+    if(request.url.indexOf(this.envService.apiUrl) > -1) {
+      // Add information about what app is making the request
+      request = request.clone({
+        setHeaders: {
+          'X-Geoapi-Application': 'taggit',
+        },
+      });
+    }
+
     return next.handle(request);
   }
 }

--- a/src/app/app.interceptors.ts
+++ b/src/app/app.interceptors.ts
@@ -71,15 +71,8 @@ export class TokenInterceptor implements HttpInterceptor {
     if (request.url.indexOf(this.envService.apiUrl) > -1) {
       // Add information about what app is making the request
 
-      // Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
-      // and using additional query params
+      // Using query params instead of custom headers due to https://tacc-main.atlassian.net/browse/WG-191
       let analytics_params = {};
-
-      /*request = request.clone({
-        setHeaders: {
-          'X-Geoapi-Application': 'hazmapper',
-        },
-      });*/
 
       analytics_params = { ...analytics_params, application: 'taggit' };
 
@@ -92,13 +85,6 @@ export class TokenInterceptor implements HttpInterceptor {
           guestUuid = uuidv4();
           localStorage.setItem('guestUuid', guestUuid);
         }
-        /*Disabling custom headers due to https://tacc-main.atlassian.net/browse/WG-191
-        request = request.clone({
-          setHeaders: {
-            'X-Guest-UUID': guestUuid,
-          },
-        });
-        */
         analytics_params = { ...analytics_params, guest_uuid: guestUuid };
       }
       /* Send analytics-related params to projects endpoint only (until we use headers

--- a/src/app/app.interceptors.ts
+++ b/src/app/app.interceptors.ts
@@ -81,7 +81,7 @@ export class TokenInterceptor implements HttpInterceptor {
         },
       });*/
 
-      analytics_params = { ...analytics_params, application: 'hazmapper' };
+      analytics_params = { ...analytics_params, application: 'taggit' };
 
       // for guest users, add a unique id
       if (!this.authSvc.isLoggedIn()) {

--- a/src/app/app.interceptors.ts
+++ b/src/app/app.interceptors.ts
@@ -78,7 +78,7 @@ export class TokenInterceptor implements HttpInterceptor {
 
       // for guest users, add a unique id
       if (!this.authSvc.isLoggedIn()) {
-        // Get (or create of needed) the guestUserID in local storage
+        // Get (or create if needed) the guestUserID in local storage
         let guestUuid = localStorage.getItem('guestUuid');
 
         if (!guestUuid) {


### PR DESCRIPTION
## Overview: ##

~This PR adds the application information (i.e. "taggit", "hazmapper") to the request header to be used by the backend for analytics-related logging.~

This PR adds the application information (i.e. "taggit", "hazmapper") to requests to be used for or analytics-related logging.  This PR has been updated to disable added headers and use query params on a single route instead. Headers can't be used due to https://tacc-main.atlassian.net/browse/WG-191 . The use of headers is left in code but commented out; to be re-used in WG-192 when we start using Taips V3.

See https://github.com/TACC-Cloud/geoapi/pull/161 for more details.

## Related Jira tickets: ##

* [WG-140](https://tacc-main.atlassian.net/browse/WG-140)
* [WG-191](https://tacc-main.atlassian.net/browse/WG-191)

## Testing Steps: ##
See https://github.com/TACC-Cloud/geoapi/pull/161
