### PR TITLE
task/WG-287 - File listing fix taggit

### DIFF
--- a/src/app/components/modal-download-selector/modal-download-selector.component.ts
+++ b/src/app/components/modal-download-selector/modal-download-selector.component.ts
@@ -145,19 +145,20 @@ export class ModalDownloadSelectorComponent implements OnInit {
 
           this.currentPath.next(this.currentDirectory.path);
           this.passbackData[1] = this.currentDirectory.path;
-          debugger;
 
-          // Add '..' entry for users to move to parent path
-          const backPath = {
-            name: '..',
-            format: 'folder',
-            type: 'dir',
-            mimeType: 'test/directory',
-            size: 8192,
-            path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
-            system: this.currentDirectory.system,
-          };
-          files.unshift(backPath);
+          // If this is the first load, add the '..' entry for users to move to parent path
+          if (this.offset === 0) {
+            const backPath = {
+              name: '..',
+              format: 'folder',
+              type: 'dir',
+              mimeType: 'test/directory',
+              size: 8192,
+              path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
+              system: this.currentDirectory.system,
+            };
+            this.filesList.unshift(backPath);
+          }
 
           this.inProgress = false;
           this.filesList = this.filesList.concat(files);

--- a/src/app/components/modal-file-browser/modal-file-browser.component.ts
+++ b/src/app/components/modal-file-browser/modal-file-browser.component.ts
@@ -174,18 +174,20 @@ export class ModalFileBrowserComponent implements OnInit {
 
           this.currentPath.next(this.currentDirectory.path);
 
-          // Add '..' entry for users to move to parent path
-          const backPath = {
-            name: '..',
-            format: 'folder',
-            type: 'dir',
-            mimeType: 'test/directory',
-            size: 8192,
-            path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
-            system: this.currentDirectory.system,
-          };
-          files.unshift(backPath);
-
+          // If this is the first load, add the '..' entry for users to move to parent path
+          if (this.offset === 0) {
+            const backPath = {
+              name: '..',
+              format: 'folder',
+              type: 'dir',
+              mimeType: 'test/directory',
+              size: 8192,
+              path: this.tapisFilesService.getParentPath(this.currentDirectory.path),
+              system: this.currentDirectory.system,
+            };
+            this.filesList.unshift(backPath);
+          }
+   
           this.inProgress = false;
           this.retrievalError = false;
           this.filesList = this.filesList.concat(files);


### PR DESCRIPTION
## Overview: ##

Fixed multiple parent `..` folders that could appear when multiple file listings are done during infinite scroll. Also fixes a bug where infinite scroll was not working as intended and subsequent requests after the first one were not being made

## Related Jira tickets: ##

* [WG-287](https://tacc-main.atlassian.net/browse/WG-287)

## Summary of Changes: ##

- Added a condition where the `..` backPath folder is only added in the first load when the offset is 0 
- Made a change so that the `..` backPath is added to the `filesList` array instead of the `files` array from the api response. Originally, the change in length from the added backPath entry was causing the offset to be 1 larger than expected which broke the infinite scroll functionality

## Testing Steps: ##
1. Start the application and open the file browser modal by selecting `Import Images from DesignSafe` in the menu
2. Select a system with lots of files/folders (`Published Data` has hundreds)
3. Scroll the listing and ensure that the listing works smoothly and there are no duplicate `..` folders. Can also monitor the Network tab to ensure new data with updated offset is being fetched
4. Repeat the above steps with the download selector modal which can be opened by selected `Export to DesignSafe` menu option

## UI Photos:

No UI changes

## Notes: ##
