### PR TITLE
task/WG-320 Taggit Edit Project Fields Fix

### DIFF
--- a/src/app/components/modal-current-project/modal-current-project.component.html
+++ b/src/app/components/modal-current-project/modal-current-project.component.html
@@ -11,12 +11,13 @@
       formControlName="name"
       appearance="filled"
       required="true"
+      readonly="true"
     />
   </mat-form-field>
 
   <mat-form-field>
     <mat-label>Description</mat-label>
-    <textarea matInput formControlName="description" required="true"></textarea>
+    <textarea matInput formControlName="description" required="true" readonly="true"></textarea>
   </mat-form-field>
 
   <div class="button-group small">
@@ -38,16 +39,6 @@
       (click)="delete()"
     >
       Delete
-    </button>
-    <button
-      mat-raised-button
-      color="primary"
-      class="button small align-right"
-      type="submit"
-      (click)="update()"
-      [disabled]="!projCreateForm.valid"
-    >
-      Update
     </button>
   </div>
 </form>


### PR DESCRIPTION
## Overview: ##

## Related Jira tickets: ##

* [WG-320](https://tacc-main.atlassian.net/browse/WG-320)

## Summary of Changes: ##

- Made name and description fields read-only. User will have to update these fields directly from Hazmapper

## Testing Steps: ##
1. Open a map in taggit and from the menu click `Current Gallery/Map`. Ensure that both the fields are not editable

## UI Photos:

No UI changes 

## Notes: ##
