### PR TITLE
tapis tenant clients for taggit under wma service account

### DIFF
--- a/src/app/services/env.service.ts
+++ b/src/app/services/env.service.ts
@@ -106,7 +106,7 @@ export class EnvService {
       this._designSafePortalUrl = this.getDesignSafePortalUrl(environment.backend);
       this._hazmapperUrl = this.getHazmapperUrl(environment.backend);
       this._baseHref = '/';
-      this._clientId = 'taggit.localhost';
+      this._clientId = 'taggitds.localhost';
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname) && pathname.startsWith('/taggit-dev')) {
       this._env = EnvironmentType.Dev;
       this._apiUrl = this.getApiUrl(this.env);

--- a/src/app/services/env.service.ts
+++ b/src/app/services/env.service.ts
@@ -106,7 +106,7 @@ export class EnvService {
       this._designSafePortalUrl = this.getDesignSafePortalUrl(environment.backend);
       this._hazmapperUrl = this.getHazmapperUrl(environment.backend);
       this._baseHref = '/';
-      this._clientId = 'taggitds.localhost';
+      this._clientId = 'taggitds.local';
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname) && pathname.startsWith('/taggit-dev')) {
       this._env = EnvironmentType.Dev;
       this._apiUrl = this.getApiUrl(this.env);

--- a/src/app/services/env.service.ts
+++ b/src/app/services/env.service.ts
@@ -112,28 +112,28 @@ export class EnvService {
       this._apiUrl = this.getApiUrl(this.env);
       this._designSafePortalUrl = this.getDesignSafePortalUrl(this.env);
       this._hazmapperUrl = this.getHazmapperUrl(this.env);
-      this._clientId = 'taggit.dev';
+      this._clientId = 'taggitds.dev';
       this._baseHref = '/taggit-dev/';
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname) && pathname.startsWith('/taggit-exp')) {
       this._env = EnvironmentType.Experimental;
       this._apiUrl = this.getApiUrl(this.env);
       this._hazmapperUrl = this.getHazmapperUrl(this.env);
       this._designSafePortalUrl = this.getDesignSafePortalUrl(this.env);
-      this._clientId = 'taggit.experimental';
+      this._clientId = 'taggitds.experimental';
       this._baseHref = '/taggit-exp/';
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname) && pathname.startsWith('/taggit-staging')) {
       this._env = EnvironmentType.Staging;
       this._apiUrl = this.getApiUrl(this.env);
       this._designSafePortalUrl = this.getDesignSafePortalUrl(this.env);
       this._hazmapperUrl = this.getHazmapperUrl(this.env);
-      this._clientId = 'taggit.staging';
+      this._clientId = 'taggitds.staging';
       this._baseHref = '/taggit-staging/';
     } else if (/^hazmapper.tacc.utexas.edu/.test(hostname)) {
       this._env = EnvironmentType.Production;
       this._apiUrl = this.getApiUrl(this.env);
       this._designSafePortalUrl = this.getDesignSafePortalUrl(this.env);
       this._hazmapperUrl = this.getHazmapperUrl(this.env);
-      this._clientId = 'taggit.prod';
+      this._clientId = 'taggitds.prod';
       this._baseHref = '/taggit/';
     } else if (/^taggit-tacc.github.io/.test(hostname)) {
       this._env = EnvironmentType.Production;


### PR DESCRIPTION
## Overview: ##

New tapis tenant clients for taggit application in DS v3 using the wma_prtl account.

## Related Jira tickets: ##

* [WG-329](https://tacc-main.atlassian.net/browse/WG-329)

## Summary of Changes: ##

- Created new tenant clients for taggit using the wma service account.
- Updated the client_id for the four host environments (exp, dev, pprd/staging, prod).

## Testing Steps: ##
1. Look at code and see change in client_id values.
2. Compare with new client generated values in UT Stache (https://stache.utexas.edu/entry/fd73b705e6fd3ee97c20e71c3e3bd6d8 ).

## UI Photos:

## Notes: ##

- Once this is merged into `main`, need to coordinate updating the `secrets` on each deployment host before redeploying the new taggit updates. Start with exp, then dev, pprd/staging and eventually prod (possibly scheduled).