### PR TITLE
task/WG-192: Update taggit to use headers for analytics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         node-version: 14.x
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         node-version: 14
         cache: npm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,11 @@ jobs:
       with:
         node-version: 14.x
 
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        node-version: 14
+        cache: npm
+        cache-dependency-path: angular/package-lock.json
 
     - name: npm install
       run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,9 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Node.js for use with actions
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
-
-    - uses: actions/cache@v4
+      uses: actions/setup-node@v4
       with:
         node-version: 14
         cache: npm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         node-version: 14
         cache: npm
-        cache-dependency-path: angular/package-lock.json
+        cache-dependency-path: package-lock.json
 
     - name: npm install
       run: npm install


### PR DESCRIPTION
## Overview: ##

Resolves WG-192 and uses analytics-related headers instead of query params.  We had to use query params due to WSO2/tapisv2 not being able to accept our headers.

## Related Jira tickets: ##

* [WG-192](https://tacc-main.atlassian.net/browse/WG-192)

## Testing ##

See https://github.com/TACC-Cloud/geoapi/pull/241

don't forget `backend: EnvironmentType.Local,`

