### PR TITLE
task/WG-611: handle symbolic links in older projects 

### DIFF
--- a/src/app/components/modal-download-selector/modal-download-selector.component.html
+++ b/src/app/components/modal-download-selector/modal-download-selector.component.html
@@ -30,8 +30,8 @@
     [ngClass]="{ selected: selectedFiles.has(file.path) }"
   >
     <div class="clickable" (dblclick)="browse(file)">
-      <i class="fas fa-folder" *ngIf="file.type === 'dir' || file.type === 'symbolic_link'"></i>
-      <i class="far fa-file" *ngIf="file.type !== 'dir' && file.type !== 'symbolic_link'"></i>
+      <i class="fas fa-folder" *ngIf="file.type === 'dir'"></i>
+      <i class="far fa-file" *ngIf="file.type !== 'dir'"></i>
       <span> {{ file.name }} </span>
     </div>
     <div class="size">

--- a/src/app/components/modal-download-selector/modal-download-selector.component.html
+++ b/src/app/components/modal-download-selector/modal-download-selector.component.html
@@ -30,8 +30,8 @@
     [ngClass]="{ selected: selectedFiles.has(file.path) }"
   >
     <div class="clickable" (dblclick)="browse(file)">
-      <i class="fas fa-folder" *ngIf="file.type === 'dir'"></i>
-      <i class="far fa-file" *ngIf="file.type !== 'dir'"></i>
+      <i class="fas fa-folder" *ngIf="file.type === 'dir' || file.type === 'symbolic_link'"></i>
+      <i class="far fa-file" *ngIf="file.type !== 'dir' && file.type !== 'symbolic_link'"></i>
       <span> {{ file.name }} </span>
     </div>
     <div class="size">

--- a/src/app/components/modal-file-browser/modal-file-browser.component.html
+++ b/src/app/components/modal-file-browser/modal-file-browser.component.html
@@ -46,8 +46,8 @@
       (click)="select($event, file, fileIndex)"
       (dblclick)="browse(file)"
     >
-      <i class="fas fa-folder" *ngIf="file.type === 'dir'"></i>
-      <i class="far fa-file" *ngIf="file.type !== 'dir'"></i>
+      <i class="fas fa-folder" *ngIf="file.type === 'dir' || file.type === 'symbolic_link'"></i>
+      <i class="far fa-file" *ngIf="file.type !== 'dir' && file.type !== 'symbolic_link' "></i>
       <span> {{ file.name }} </span>
     </div>
     <div class="size">

--- a/src/app/components/modal-file-browser/modal-file-browser.component.ts
+++ b/src/app/components/modal-file-browser/modal-file-browser.component.ts
@@ -137,7 +137,9 @@ export class ModalFileBrowserComponent implements OnInit {
   browse(file: RemoteFile) {
     this.selectedPath = file.path;
     this.selectedSystem = this.selectedSystem; // Self-assignment keeps the system name from disappearing while browsing subfolders
-    if (file.type !== 'dir') {
+
+    // directories are navigatable as well as symbolic_links which are used in older DS projects to map to new structure.
+    if (file.type !== 'dir' && file.type !== 'symbolic_link') {
       return;
     }
     this.currentDirectory = file;

--- a/src/app/components/modal-file-browser/modal-file-browser.component.ts
+++ b/src/app/components/modal-file-browser/modal-file-browser.component.ts
@@ -138,7 +138,7 @@ export class ModalFileBrowserComponent implements OnInit {
     this.selectedPath = file.path;
     this.selectedSystem = this.selectedSystem; // Self-assignment keeps the system name from disappearing while browsing subfolders
 
-    // directories are navigatable as well as symbolic_links which are used in older DS projects to map to new structure.
+    // Directories and symbolic_links (used in older DesignSafe projects) are navigable.
     if (file.type !== 'dir' && file.type !== 'symbolic_link') {
       return;
     }


### PR DESCRIPTION
## Overview: ##

This PR handles symbolic links like directories when browsing files.  This was an issue as last year older DS published projects were re-worked to a new file structure and symbolic files were used connect the old structure with the new structure.  This PR is the Taggit equivalent of https://github.com/TACC-Cloud/hazmapper/pull/405

## PR Status: ##

* [X] Ready.

## Related Jira tickets: ##

* [WG-611](https://tacc-main.atlassian.net/browse/WG-611)

## Summary of Changes: ##

## Testing Steps: ##
1. Import to from DesignSafe
2. Navigate to Published Data and project PRJ-3379
3. Then add any images under `Mission--marshall-fire-reconnaissance-2022/data/Geoscience-collection--raw-data/data/RApp/uwrapid/Home`

