### PR TITLE
Remove unused overlay code

### DIFF
--- a/src/app/components/control-bar/control-bar.component.ts
+++ b/src/app/components/control-bar/control-bar.component.ts
@@ -249,7 +249,6 @@ export class ControlBarComponent implements OnInit {
 
   getDataForProject(p: Project): void {
     this.geoDataService.getFeatures(p.id);
-    this.geoDataService.getOverlays(p.id);
     this.geoDataService.getPointClouds(p.id);
   }
 

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -6,7 +6,6 @@ import { instance, mock, spy, when } from 'ts-mockito';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { of } from 'rxjs';
 import { featureFixture } from '../../fixtures/feature.fixture';
-import { overlayFixture } from '../../fixtures/overlay.fixture';
 import { FeatureCollection } from '../../models/models';
 
 class MockActivatedRoute extends ActivatedRoute {
@@ -42,7 +41,6 @@ describe('MapComponent', () => {
     fixture = TestBed.createComponent(MapComponent);
     component = fixture.componentInstance;
 
-    when(MockData.activeOverlay).thenReturn(of(overlayFixture));
     when(MockData.activeFeature).thenReturn(of(featureFixture));
     when(MockData.features).thenReturn(of(new FeatureCollection()));
     when(MockData.basemap).thenReturn(of('roads'));

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -6,12 +6,10 @@ import 'leaflet.markercluster';
 import { GeoDataService } from '../../services/geo-data.service';
 import { createMarker } from '../../utils/leafletUtils';
 import { Feature } from 'geojson';
-import { FeatureGroup, ImageOverlay, LatLng, LeafletMouseEvent } from 'leaflet';
+import { FeatureGroup, LatLng, LeafletMouseEvent } from 'leaflet';
 import * as turf from '@turf/turf';
 import { AllGeoJSON } from '@turf/helpers';
 import { filter, skip } from 'rxjs/operators';
-import { Overlay } from '../../models/models';
-import { EnvService } from '../../services/env.service';
 
 @Component({
   selector: 'app-map',
@@ -22,13 +20,10 @@ export class MapComponent implements OnInit {
   map: L.Map;
   mapType = 'normal';
   activeFeature: Feature;
-  activeOverlay: Overlay;
   features: FeatureGroup = new FeatureGroup();
-  overlays: Map<number, ImageOverlay>;
 
   constructor(
     private GeoDataService: GeoDataService,
-    private envService: EnvService,
     private route: ActivatedRoute
   ) {
     // Have to bind these to keep this being this
@@ -40,7 +35,6 @@ export class MapComponent implements OnInit {
     // const mapType: string = this.route.snapshot.queryParamMap.get('mapType');
     // this.projectId = +this.route.snapshot.paramMap.get("projectId");
     // this.cluster = this.route.snapshot.queryParamMap.get('mapType');
-    this.overlays = new Map();
     this.map = new L.Map('map', {
       center: [40, -80],
       zoom: 9,
@@ -70,9 +64,6 @@ export class MapComponent implements OnInit {
     this.map.on('mousemove', (ev: LeafletMouseEvent) =>
       this.mouseEventHandler(ev)
     );
-    this.GeoDataService.activeOverlay.pipe(skip(1)).subscribe((next) => {
-      this.addRemoveOverlay(next);
-    });
 
     // Listen on the activeFeature stream and zoom map to that feature when it changes
     this.GeoDataService.activeFeature
@@ -97,24 +88,6 @@ export class MapComponent implements OnInit {
         this.map.addLayer(baseOSM);
       }
     });
-  }
-
-  addRemoveOverlay(ov: Overlay): void {
-    if (this.overlays.has(ov.id)) {
-      this.features.removeLayer(this.overlays.get(ov.id));
-      this.overlays.delete(ov.id);
-    } else {
-      const overlay = L.imageOverlay(
-        this.envService.apiUrl + '/assets/' + ov.path,
-        [
-          [ov.minLat, ov.minLon],
-          [ov.maxLat, ov.maxLon],
-        ]
-      );
-      this.overlays.set(ov.id, overlay);
-      this.features.addLayer(overlay);
-    }
-    this.map.fitBounds(this.features.getBounds());
   }
 
   mouseEventHandler(ev: any): void {

--- a/src/app/models/models.ts
+++ b/src/app/models/models.ts
@@ -182,18 +182,6 @@ export interface FeatureStyles {
 
 export class FeatureStyles implements FeatureStyles {}
 
-export interface Overlay {
-  id: number;
-  path: string;
-  uuid: string;
-  minLon: number;
-  minLat: number;
-  maxLon: number;
-  maxLat: number;
-  project_id: number;
-  label: string;
-}
-
 interface AppGeoJSONFeature extends GeoJSONFeature {
   assets?: Array<IFeatureAsset>;
   styles?: FeatureStyles;

--- a/src/app/services/geo-data.service.ts
+++ b/src/app/services/geo-data.service.ts
@@ -8,7 +8,6 @@ import {
   FeatureStyles,
   IFeatureAsset,
   IPointCloud,
-  Overlay,
   TagGroup,
   Tag,
   TagValue,
@@ -36,8 +35,6 @@ export class GeoDataService {
   private _activeFeature: BehaviorSubject<any>;
   private _mapMouseLocation: BehaviorSubject<any>;
   private _basemap: BehaviorSubject<any>;
-  private _overlays: BehaviorSubject<any>;
-  private _activeOverlay: BehaviorSubject<any>;
   private _pointClouds: BehaviorSubject<Array<IPointCloud>> =
     new BehaviorSubject<Array<IPointCloud>>(null);
   public readonly pointClouds: Observable<Array<IPointCloud>> =
@@ -98,10 +95,6 @@ export class GeoDataService {
 
     // For the style of the basemap, defaults to OpenStreetmap
     this._basemap = new BehaviorSubject<any>('roads');
-
-    // Holds all of the overlays on a project
-    this._overlays = new BehaviorSubject<any>(null);
-    this._activeOverlay = new BehaviorSubject<any>(null);
   }
 
   getFeature(
@@ -492,38 +485,6 @@ export class GeoDataService {
       );
   }
 
-  getOverlays(projectId: number): void {
-    this.http
-      .get(this.envService.apiUrl + `/projects/${projectId}/overlays/`)
-      .subscribe((ovs: Array<Overlay>) => {
-        this._overlays.next(ovs);
-      });
-  }
-
-  addOverlay(
-    projectId: number,
-    file: File,
-    label: string,
-    minLat: number,
-    maxLat: number,
-    minLon: number,
-    maxLon: number
-  ) {
-    const payload = new FormData();
-    payload.append('file', file);
-    payload.append('label', label);
-    payload.append('minLat', minLat.toFixed(6));
-    payload.append('maxLat', maxLat.toFixed(6));
-    payload.append('minLon', minLon.toFixed(6));
-    payload.append('maxLon', maxLon.toFixed(6));
-
-    this.http
-      .post(this.envService.apiUrl + `/projects/${projectId}/overlays/`, payload)
-      .subscribe((resp) => {
-        this.getOverlays(projectId);
-      });
-  }
-
   // Call on getFeatures (each time feature update)
   getGroups(featureList: Feature[]): void {
     const groups = new Map<string, TagGroup>();
@@ -713,10 +674,6 @@ export class GeoDataService {
     );
   }
 
-  public get overlays(): Observable<Array<Overlay>> {
-    return this._overlays.asObservable();
-  }
-
   public get features(): Observable<FeatureCollection> {
     return this._features.asObservable();
   }
@@ -736,14 +693,6 @@ export class GeoDataService {
     } else {
       this._activeFeature.next(null);
     }
-  }
-
-  public get activeOverlay(): Observable<Overlay> {
-    return this._activeOverlay.asObservable();
-  }
-
-  public set activeOverlay(ov) {
-    this._activeOverlay.next(ov);
   }
 
   public get mapMouseLocation(): Observable<LatLng> {


### PR DESCRIPTION
## Overview: ##

Remove use of **always unused** overlay routes as deprecated in https://github.com/TACC-Cloud/geoapi/pull/293

note, taggit's `src/app/services/geo-data.service.ts` has lots of use of enpoints that it may or may not call but then doesn't use results.  Overlay is one of them so this needed to be removed as now deprecated.

## Related Jira tickets: ##

None